### PR TITLE
Fix favicon

### DIFF
--- a/app/app/src/layouts/Layout.astro
+++ b/app/app/src/layouts/Layout.astro
@@ -2,7 +2,7 @@
 import '@fontsource-variable/inter'
 import '~/styles/style.scss'
 
-import iconUrl from '~/assets/icon.png?url'
+import icon from '~/assets/icon.png'
 
 export interface Props
 {
@@ -42,7 +42,7 @@ const {
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width; initial-scale=1.0" />
 
-		<link rel="icon" href={ iconUrl } type="image/png+xml" />
+		<link rel="icon" href={icon.src} type="image/png+xml" />
 
 		<title>{title}</title>
 		{description && <meta name="description" content={description} />}


### PR DESCRIPTION
Change the image import method to fix the favicon.

Before this PR, the `icon.JlXlGPWG.png` file requested for the favicon was not generated during build.